### PR TITLE
Add partial period flag to required lines for monthly split log returns

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@envage/water-abstraction-helpers",
-  "version": "2.2.0",
+  "version": "2.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/returns/lines.js
+++ b/src/returns/lines.js
@@ -56,6 +56,7 @@ const getWeeks = (startDate, endDate) => {
  * @return {Array} list of required return lines
  */
 const getMonths = (startDate, endDate, isPartialPeriod = false) => {
+  const method = isPartialPeriod ? 'isBefore' : 'isSameOrBefore';
   const datePtr = moment(startDate);
   const lines = [];
   do {
@@ -66,7 +67,7 @@ const getMonths = (startDate, endDate, isPartialPeriod = false) => {
     });
     datePtr.add(1, 'month');
   }
-  while (isPartialPeriod ? datePtr.isBefore(endDate, 'month') : datePtr.isSameOrBefore(endDate, 'month'));
+  while (datePtr[method](endDate, 'month'));
   return lines;
 };
 

--- a/src/returns/lines.js
+++ b/src/returns/lines.js
@@ -52,9 +52,10 @@ const getWeeks = (startDate, endDate) => {
  * Get required monthly return lines
  * @param {String} startDate - YYYY-MM-DD start date of return cycle
  * @param {String} endDate - YYYY-MM-DD end date of return cycle
+ * @param {Boolean} isPartialPeriod if return is for a partial period (if it is a split log)
  * @return {Array} list of required return lines
  */
-const getMonths = (startDate, endDate) => {
+const getMonths = (startDate, endDate, isPartialPeriod = false) => {
   const datePtr = moment(startDate);
   const lines = [];
   do {
@@ -65,7 +66,7 @@ const getMonths = (startDate, endDate) => {
     });
     datePtr.add(1, 'month');
   }
-  while (datePtr.isSameOrBefore(endDate, 'month'));
+  while (isPartialPeriod ? datePtr.isBefore(endDate, 'month') : datePtr.isSameOrBefore(endDate, 'month'));
   return lines;
 };
 
@@ -88,9 +89,10 @@ const getYears = (startDate, endDate) => {
  * @param {String} startDate - YYYY-MM-DD
  * @param {String} endDate - YYYY-MM-DD
  * @param {String} frequency
+ * @param {Boolean} isPartialPeriod - split logs
  * @return {Array} array of required lines
  */
-const getRequiredLines = (startDate, endDate, frequency) => {
+const getRequiredLines = (startDate, endDate, frequency, isPartialPeriod) => {
   const map = {
     day: getDays,
     week: getWeeks,
@@ -99,7 +101,7 @@ const getRequiredLines = (startDate, endDate, frequency) => {
   };
 
   if (map[frequency]) {
-    return map[frequency](startDate, endDate);
+    return map[frequency](startDate, endDate, isPartialPeriod);
   }
 
   throw new Error(`Unknown frequency ${frequency}`);

--- a/test/returns/lines.js
+++ b/test/returns/lines.js
@@ -108,8 +108,8 @@ experiment('getMonths', () => {
   test('generates correct months for partial period', async () => {
     const months = getMonths('2018-01-01', '2018-12-18', true);
     // last month should not be included for a partial period
-    expectedMonths.pop();
-    expect(months).to.equal(expectedMonths);
+    const expected = expectedMonths.slice(0, -1);
+    expect(months).to.equal(expected);
   });
 
   test('generates a month if the start date is anywhere within the month', async () => {

--- a/test/returns/lines.js
+++ b/test/returns/lines.js
@@ -75,6 +75,20 @@ experiment('getDays', () => {
 });
 
 experiment('getMonths', () => {
+  const expectedMonths = [
+    { startDate: '2018-01-01', endDate: '2018-01-31', timePeriod: 'month' },
+    { startDate: '2018-02-01', endDate: '2018-02-28', timePeriod: 'month' },
+    { startDate: '2018-03-01', endDate: '2018-03-31', timePeriod: 'month' },
+    { startDate: '2018-04-01', endDate: '2018-04-30', timePeriod: 'month' },
+    { startDate: '2018-05-01', endDate: '2018-05-31', timePeriod: 'month' },
+    { startDate: '2018-06-01', endDate: '2018-06-30', timePeriod: 'month' },
+    { startDate: '2018-07-01', endDate: '2018-07-31', timePeriod: 'month' },
+    { startDate: '2018-08-01', endDate: '2018-08-31', timePeriod: 'month' },
+    { startDate: '2018-09-01', endDate: '2018-09-30', timePeriod: 'month' },
+    { startDate: '2018-10-01', endDate: '2018-10-31', timePeriod: 'month' },
+    { startDate: '2018-11-01', endDate: '2018-11-30', timePeriod: 'month' },
+    { startDate: '2018-12-01', endDate: '2018-12-31', timePeriod: 'month' }
+  ];
   test('generates a line for each month', async () => {
     const months = getMonths('2018-01-01', '2018-12-31');
     expect(months.length).to.equal(12);
@@ -88,20 +102,14 @@ experiment('getMonths', () => {
 
   test('generates correct months', async () => {
     const months = getMonths('2018-01-01', '2018-12-31');
-    expect(months).to.equal([
-      { startDate: '2018-01-01', endDate: '2018-01-31', timePeriod: 'month' },
-      { startDate: '2018-02-01', endDate: '2018-02-28', timePeriod: 'month' },
-      { startDate: '2018-03-01', endDate: '2018-03-31', timePeriod: 'month' },
-      { startDate: '2018-04-01', endDate: '2018-04-30', timePeriod: 'month' },
-      { startDate: '2018-05-01', endDate: '2018-05-31', timePeriod: 'month' },
-      { startDate: '2018-06-01', endDate: '2018-06-30', timePeriod: 'month' },
-      { startDate: '2018-07-01', endDate: '2018-07-31', timePeriod: 'month' },
-      { startDate: '2018-08-01', endDate: '2018-08-31', timePeriod: 'month' },
-      { startDate: '2018-09-01', endDate: '2018-09-30', timePeriod: 'month' },
-      { startDate: '2018-10-01', endDate: '2018-10-31', timePeriod: 'month' },
-      { startDate: '2018-11-01', endDate: '2018-11-30', timePeriod: 'month' },
-      { startDate: '2018-12-01', endDate: '2018-12-31', timePeriod: 'month' }
-    ]);
+    expect(months).to.equal(expectedMonths);
+  });
+
+  test('generates correct months for partial period', async () => {
+    const months = getMonths('2018-01-01', '2018-12-18', true);
+    // last month should not be included for a partial period
+    expectedMonths.pop();
+    expect(months).to.equal(expectedMonths);
   });
 
   test('generates a month if the start date is anywhere within the month', async () => {


### PR DESCRIPTION
WATER-2012

Add isPartialPeriod flag to getRequiredLines and getMonths functions so that the last month in the first half of split logs is not included in required lines