### PR TITLE
Fixes issue in billable days calculation when abs period ends on 1 April

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@envage/water-abstraction-helpers",
-  "version": "4.3.6",
+  "version": "4.3.7",
   "description": "Contains functions for processing water abstraction data which are shared across multiple projects",
   "main": "./src/index.js",
   "scripts": {

--- a/src/charging/billable-days.js
+++ b/src/charging/billable-days.js
@@ -15,6 +15,8 @@ const ABS_PERIOD_SCHEMA = Joi.object({
 
 const DATE_SCHEMA = Joi.string().regex(/^[0-9]{4}-[0-9]{2}-[0-9]{2}$/);
 
+const DATE_FORMAT = 'YYYY-MM-DD';
+
 /**
  * Given a date, calculates the financial year ending
  * E.g. for 2019/2020, returns 2020
@@ -65,6 +67,8 @@ const getIntersection = ranges => {
     : [startDate, endDate];
 };
 
+const formatDate = str => moment(str).format(DATE_FORMAT);
+
 /**
  * Gets the number of billable days between the start and end date,
  * when the abstraction period is taken into account
@@ -90,7 +94,10 @@ const getBillableDays = (absPeriod, startDate, endDate) => {
     : [[absStart, absEnd]];
 
   // Create time range for the billing period
-  const billingPeriod = [startDate, endDate];
+  const billingPeriod = [
+    formatDate(startDate),
+    formatDate(endDate)
+  ];
 
   return absPeriodRanges.reduce((acc, range) => {
     const intersection = getIntersection([range, billingPeriod]);

--- a/src/charging/billable-days.js
+++ b/src/charging/billable-days.js
@@ -1,9 +1,7 @@
 'use strict';
 
 const Joi = require('@hapi/joi');
-
-const MomentRange = require('moment-range');
-const moment = MomentRange.extendMoment(require('moment'));
+const moment = require('moment');
 
 const MONTH_SCHEMA = Joi.number().integer().min(1).max(12).required();
 const DAY_SCHEMA = Joi.number().integer().min(1).max(31).required();
@@ -55,6 +53,19 @@ const getTotalDays = (startDate, endDate) => {
 };
 
 /**
+ * Gets the intersecting date range between the supplied ranges
+ * @param {Array} ranges - e.g. [[startDate, endDate], []...]
+ * @returns {Array|null}
+ */
+const getIntersection = ranges => {
+  const startDate = ranges.map(range => range[0]).sort().pop();
+  const endDate = ranges.map(range => range[1]).sort()[0];
+  return moment(startDate).isAfter(endDate, 'day')
+    ? null
+    : [startDate, endDate];
+};
+
+/**
  * Gets the number of billable days between the start and end date,
  * when the abstraction period is taken into account
  * @param {Object} absPeriod - the abstraction period start/end day/month
@@ -74,17 +85,19 @@ const getBillableDays = (absPeriod, startDate, endDate) => {
   const absEnd = getFinancialYearDate(absPeriod.endDay, absPeriod.endMonth, financialYear);
 
   // Create time ranges for the abs period
-  const ranges = moment(absEnd).isBefore(absStart, 'day')
-    ? [moment.range(startDate, absEnd), moment.range(absStart, endDate)]
-    : [moment.range(absStart, absEnd)];
+  const absPeriodRanges = moment(absEnd).isBefore(absStart, 'day')
+    ? [[startDate, absEnd], [absStart, endDate]]
+    : [[absStart, absEnd]];
 
-  // Create time range for billing period
-  const billRange = moment.range(startDate, endDate);
+  // Create time range for the billing period
+  const billingPeriod = [startDate, endDate];
 
-  // Calculate intersections between abs time range(s) and billing period range
-  return ranges.reduce((acc, range) => {
-    const intersection = billRange.intersect(range);
-    return acc + (intersection ? intersection.diff('days') + 1 : 0);
+  return absPeriodRanges.reduce((acc, range) => {
+    const intersection = getIntersection([range, billingPeriod]);
+
+    return acc + (
+      intersection ? moment(intersection[1]).diff(intersection[0], 'day') + 1 : 0
+    );
   }, 0);
 };
 

--- a/test/charging/billable-days.js
+++ b/test/charging/billable-days.js
@@ -23,6 +23,12 @@ const absPeriods = {
     startMonth: 12,
     endDay: 30,
     endMonth: 4
+  },
+  doubleRange2: {
+    startDay: 31,
+    startMonth: 10,
+    endDay: 1,
+    endMonth: 4
   }
 };
 
@@ -119,6 +125,23 @@ experiment('charging.getBillableDays', () => {
     test('when there are no billable days, zero is returned', async () => {
       const result = charging.getBillableDays(absPeriods.doubleRange, '2018-05-01', '2018-11-30');
       expect(result).to.equal(0);
+    });
+  });
+
+  experiment('when the abs period ends on the 1st April', async () => {
+    test('the first day of April is included for a full year', async () => {
+      const result = charging.getBillableDays(absPeriods.doubleRange2, '2021-04-01', '2022-03-31');
+      expect(result).to.equal(153);
+    });
+
+    test('the first day of April is not included when it is not in the charge period', async () => {
+      const result = charging.getBillableDays(absPeriods.doubleRange2, '2021-04-02', '2022-03-31');
+      expect(result).to.equal(152);
+    });
+
+    test('when the end date is before the start of the abs period, only 1 April is included', async () => {
+      const result = charging.getBillableDays(absPeriods.doubleRange2, '2021-04-01', '2021-10-30');
+      expect(result).to.equal(1);
     });
   });
 });

--- a/test/charging/billable-days.js
+++ b/test/charging/billable-days.js
@@ -143,5 +143,10 @@ experiment('charging.getBillableDays', () => {
       const result = charging.getBillableDays(absPeriods.doubleRange2, '2021-04-01', '2021-10-30');
       expect(result).to.equal(1);
     });
+
+    test('when the end date is part-way through the abs period, calculates correct days', async () => {
+      const result = charging.getBillableDays(absPeriods.doubleRange2, '2021-04-01', '2021-11-30');
+      expect(result).to.equal(32);
+    });
   });
 });


### PR DESCRIPTION
`WATER-3148`

Fixes an issue with billable days calculation when the abs period end is 1 April.  (Or any single-day overlapping range).

The `moment-range` library did not calculate a single day range (same start/end date) to be an intersection as needed with the billing period.

This has been fixed with a bespoke function to calculate the intersecting range.