### PR TITLE
Apply consistent CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,66 +1,74 @@
 name: CI
 
-on:
-  push:
-    branches:
-      - '**'
+on: push
 
 jobs:
-  base-node-pipeline:
-    uses: DEFRA/water-abstraction-orchestration/.github/workflows/base-node-pipeline.yml@develop
-    with:
-      serviceName: DEFRA_water-abstraction-ui
-    secrets:
-      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-  test:
+  build:
     runs-on: ubuntu-latest
-    env:
-      DATABASE_URL: postgres://postgres:postgres@localhost:5432/permits
+
     steps:
+      # Downloads a copy of the code in your repository before running CI tests
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of sonarcloud analysis
-      - uses: actions/setup-node@v2
+
+      # Before we do anything, check we haven't accidentally left any `experiment.only()` or `test.only(` statements in
+      # the tests
+      #
+      # Reworking of https://stackoverflow.com/a/21788642/6117745
+      - name: Temporary tag check
+        run: |
+          ! grep -R 'experiment.only(\|test.only(' test
+
+      # Our projects use .nvmrc files to specify the node version to use. We can read and then output it as the result
+      # this step. Subsequent steps can then access the value
+      - name: Read Node version
+        run: echo "##[set-output name=NVMRC;]$(cat .nvmrc)"
+        # Give the step an ID to make it easier to refer to
+        id: nvm
+
+      # Gets the version to use by referring to the previous step
+      - name: Install Node
+        uses: actions/setup-node@v3
         with:
-          node-version: 14.x
-          cache: 'npm'
+          node-version: "${{ steps.nvm.outputs.NVMRC }}"
+
+      # Speeds up workflows by reading the node modules from cache. Obviously you need to run it at least once, and the
+      # cache will be updated should the package-lock.json file change
+      - name: Cache Node modules
+        uses: actions/cache@v3
+        with:
+          # npm cache files are stored in `~/.npm` on Linux/macOS
+          path: ~/.npm
+          key: ${{ runner.OS }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.OS }}-node-
+            ${{ runner.OS }}-
+
+      # Performs a clean installation of all dependencies in the `package.json` file
+      # For more information, see https://docs.npmjs.com/cli/ci.html
       - name: Install dependencies
         run: npm ci
-      - name: Test
+
+      # Run linting first. No point running the tests if there is a linting issue
+      - name: Run lint check
         run: |
-          npm run test:ci
-      - name: Upload Artifacts
-        uses: actions/upload-artifact@v3
-        with:
-          name: coverage
-          path: coverage/
+          npm run lint
 
-  Code-Climate:
-    needs: [test]
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Download artifacts
-        uses: actions/download-artifact@v2
-      - name: Upload to Code Climate
-        uses: paambaati/codeclimate-action@v3.0.0
+      # This includes an extra run step. The sonarcloud analysis will be run in a docker container with the current
+      # folder mounted as `/github/workspace`. The problem is when the lcov.info file is generated it will reference the
+      # code in the current folder. So to enable sonarcloud to matchup code coverage with the files we use sed to update
+      # the references in lcov.info
+      # https://community.sonarsource.com/t/code-coverage-doesnt-work-with-github-action/16747/6
+      - name: Run unit tests
+        run: |
+          npm test
+          sed -i 's@'$GITHUB_WORKSPACE'@/github/workspace/@g' coverage/lcov.info
+
+      - name: Analyze with SonarCloud
+        if: github.actor != 'dependabot[bot]'
+        uses: sonarsource/sonarcloud-github-action@master
         env:
-          CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
-        with:
-          coverageLocations: |
-            ${{github.workspace}}/coverage/*.lcov:lcov
-
-  Code-Cov:
-    needs: [test]
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Download artifacts
-        uses: actions/download-artifact@v2
-      - name: Upload to Codecov
-        uses: codecov/codecov-action@v2
-        with:
-          directory: ./coverage/
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This is provided automatically by GitHub
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }} # This needs to be set in your repo; settings -> secrets

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -9,12 +9,30 @@ jobs:
   publish-npm:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      # Downloads a copy of the code in your repository before running CI tests
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      # Our projects use .nvmrc files to specify the node version to use. We can read and then output it as the result
+      # this step. Subsequent steps can then access the value
+      - name: Read Node version
+        run: echo "##[set-output name=NVMRC;]$(cat .nvmrc)"
+        # Give the step an ID to make it easier to refer to
+        id: nvm
+
+      # Gets the version to use by referring to the previous step
+      - name: Install Node
+        uses: actions/setup-node@v3
         with:
-          node-version: 14
-          registry-url: https://registry.npmjs.org/
-      - run: npm ci
-      - run: npm publish
+          node-version: "${{ steps.nvm.outputs.NVMRC }}"
+
+      # Performs a clean installation of all dependencies in the `package.json` file
+      # For more information, see https://docs.npmjs.com/cli/ci.html
+      - name: Install dependencies
+        run: npm ci
+
+      # Create the package and push to https://www.npmjs.com/
+      - name: Publish package
+        run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{secrets.WATER_NPM_TOKEN}}

--- a/.labrc.js
+++ b/.labrc.js
@@ -1,13 +1,16 @@
+'use strict'
 // default settings for lab test runs.
 //
 // This is overridden if arguments are passed to lab via the command line.
 module.exports = {
-  // This version global seems to be introduced by sinon.
-  globals: '__coverage__,FinalizationRegistry,WeakRef',
   verbose: true,
-
-  'coverage-exclude': [
-    'node_modules',
-    'test'
-  ]
+  coverage: true,
+  // Means when we use *.only() in our tests we just get the output for what we've flagged rather than all output but
+  // greyed out to show it was skipped
+  'silent-skips': true,
+  // lcov reporter required for SonarCloud
+  reporter: ['console', 'html', 'lcov'],
+  output: ['stdout', 'coverage/coverage.html', 'coverage/lcov.info'],
+  // This version global seems to be introduced by sinon.
+  globals: ['__coverage__', 'FinalizationRegistry', 'WeakRef'].join(',')
 };

--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
   "scripts": {
     "test": "lab",
     "test:bail": "lab --bail",
-    "test:ci": "lab -t 55 -m 0 -r html -o coverage/coverage.html -r lcov -o coverage/lcov.info --reporter junit -o coverage/junit.xml -r console -o stdout",
     "lint": "standard",
     "lint:fix": "standard --fix",
     "version": "auto-changelog -p --commit-limit false && git add CHANGELOG.md"

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,34 @@
+# Reference for all available properties
+# https://sonarcloud.io/documentation/analysis/analysis-parameters/
+# Reference for how to glob files
+# https://docs.sonarqube.org/latest/project-administration/narrowing-the-focus/
+
+# Project key is required. You'll find it in the SonarCloud UI
+sonar.projectKey=DEFRA_water-abstraction-helpers
+sonar.organization=defra
+
+# This is the name and version displayed in the SonarCloud UI.
+sonar.projectName=water-abstraction-helpers
+
+# This will add the same links in the SonarCloud UI
+sonar.links.homepage=https://github.com/DEFRA/water-abstraction-helpers
+sonar.links.ci=https://github.com/DEFRA/water-abstraction-helpers/actions
+sonar.links.scm=https://github.com/DEFRA/water-abstraction-helpers
+sonar.links.issue=https://github.com/DEFRA/water-abstraction-team/issues
+
+# Path is relative to the sonar-project.properties file.
+# SonarCloud seems to have little intelligence when it comes to code coverage. Quite simply if it sees a code file, it
+# checks it against our coverage report and if not found flags it as uncovered. This also effects the overall coverage
+# score. In our case this means SonarCloud could flag everything under test/ as lacking code coverage!
+# We have found this combinations of `sources`, `tests` and `tests.inclusions` means SonarCloud properly understands
+# what is code and what is a test file. Note the use of ./ in `sources`. This is the only way we found to include root
+# level files and ensure they are correctly resolved when SonarCloud scans the lcov coverage data.
+sonar.sources=src
+sonar.tests=test
+sonar.test.inclusions=test/**/*.js
+
+# Encoding of the source code. Default is default system encoding
+sonar.sourceEncoding=UTF-8
+
+# Ensure SonarCloud knows where to pick up test coverage stats
+sonar.javascript.lcov.reportPaths=coverage/lcov.info


### PR DESCRIPTION
https://github.com/DEFRA/water-abstraction-team/issues/4

As a team, we are currently maintaining 11 repos and that's not including documentation, support and deployment-related stuff! What we inherited was not consistent; different CI tools were used for the same purpose and different CI steps were implemented.

An effort was made to get this under control with [water-abstraction-orchestration](https://github.com/DEFRA/water-abstraction-orchestration). But to get a handle on it in such a way as the current team can manage, we're simplifying still further.

This change updates `.github/workflows/ci.yml` to use a template we're applying across all the repos, amended to the requirements of the project. In the future, we hope to return to the lessons **water-abstraction-orchestration** taught us, if only to remove the duplication across the projects. But for now, the template hopefully simplifies and makes consistent our build process.

**Notes**

- Apply ci.yml template

This is very much based on https://github.com/DEFRA/sroc-charging-module-api/blob/main/.github/workflows/ci.yml

There is now one process, which means you'll just see the one item listed in the checks on GitHub. The steps are ordered in an effort to fail fast and/or where needed, for example, DB migrations before running tests and SonarCloud analysis after code coverage data has been generated.

- Update .labrc

This is based on https://github.com/DEFRA/sroc-charging-module-api/blob/main/.labrc.js. We use the config file to ensure we generate the coverage output in a format needed by SonarCloud.

- Add SonarCloud properties file

Previously, the CI specified the values SonarCloud needs in its steps plus there were some in the web UI. But there are a bunch of other things we can tell SonarCloud about which makes managing SonarCloud much easier.

So, we use `sonar-project.properties` files to set what the SonarCloud analysis step needs and what's useful in its UI.

- Update README with new badges

Also displays the badges we want in a layout that is consistent with most open source repos.

- Update npm-publish.yml

We have to build the package for both CI and publishing to npm so it made sense to update this workflow to use the same steps as `ci.yml.
