### PR TITLE
Remove `glob` dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,6 @@
         "airbrake-js": "^1.6.8",
         "cross-fetch": "^3.0.4",
         "dotenv": "^8.2.0",
-        "glob": "^7.1.7",
         "immutability-helper": "^3.1.1",
         "joi": "^17.4.1",
         "lodash": "^4.17.21",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "airbrake-js": "^1.6.8",
     "cross-fetch": "^3.0.4",
     "dotenv": "^8.2.0",
-    "glob": "^7.1.7",
     "immutability-helper": "^3.1.1",
     "joi": "^17.4.1",
     "lodash": "^4.17.21",

--- a/src/digitise/schema.js
+++ b/src/digitise/schema.js
@@ -29,7 +29,6 @@ const loadJson = fileName => {
  * Syncronous function to get the filename for every .json file in our `schemaPath`
  * @return {Array} Array of json filenames
  */
-
 const getJsonFilenames = () => {
   return fs.readdirSync(schemaPath)
     .filter(file => path.extname(file) === '.json')

--- a/src/digitise/schema.js
+++ b/src/digitise/schema.js
@@ -1,4 +1,3 @@
-const glob = require('glob')
 const { cloneDeep, sortBy } = require('lodash')
 const path = require('path')
 const fs = require('fs')
@@ -27,12 +26,22 @@ const loadJson = fileName => {
 }
 
 /**
+ * Syncronous function to get the filename for every .json file in our `schemaPath`
+ * @return {Array} Array of json filenames
+ */
+
+const getJsonFilenames = () => {
+  return fs.readdirSync(schemaPath)
+    .filter(file => path.extname(file) === '.json')
+}
+
+/**
  * Loads all the WR22 condition schema in an array, sorted by the schema
  * number
  * @return {Array} Array of JSON schema objects
  */
 const loadSchema = () => {
-  const files = glob.sync('*.json', { cwd: schemaPath })
+  const files = getJsonFilenames()
   const sorted = sortBy(files, getSortableFilename)
   const sortedSchemas = sorted.map(loadJson)
   return sortedSchemas.filter(schema => !schema.hidden)

--- a/test/deep-map/index.test.js
+++ b/test/deep-map/index.test.js
@@ -1,69 +1,78 @@
 'use strict'
 
 const {
+  before,
   experiment,
   test
 } = exports.lab = require('@hapi/lab').script()
 const { expect } = require('@hapi/code')
+const { trim } = require('lodash')
 
 // Thing to test
-const digitise = require('../../src/digitise')
+const deepMap = require('../../src/deep-map')
 
-experiment('digitise/index.js', () => {
-  experiment('transformNulls', () => {
-    experiment('when a string \'null\' is provided', () => {
-      test('transforms it to `null`', () => {
-        const result = digitise.transformNulls('null')
-        expect(result).to.be.null()
-      })
+experiment('deep-map/index.js', () => {
+  experiment('when an object is provided', () => {
+    let object
+
+    before(() => {
+      object = {
+        a: ' a ',
+        b: {
+          b1: ' b1 ',
+          b2: ' b2 '
+        }
+      }
     })
 
-    experiment('when an empty string is provided', () => {
-      test('transforms it to `null`', () => {
-        const result = digitise.transformNulls('')
-        expect(result).to.be.null()
+    test('recursively applies a function to every item', async () => {
+      const result = deepMap(object, item => trim(item))
+      expect(result).to.equal({
+        a: 'a',
+        b: {
+          b1: 'b1',
+          b2: 'b2'
+        }
       })
     })
+  })
 
-    experiment('when `null` is provided', () => {
-      test('leaves it as `null`', () => {
-        const result = digitise.transformNulls(null)
-        expect(result).to.be.null()
-      })
+  experiment('when an array is provided', () => {
+    let array
+
+    before(() => {
+      array = [' a ', ' b ', ' c ']
     })
 
-    experiment('when a regular string is provided', () => {
-      test('leaves it as-is', () => {
-        const result = digitise.transformNulls('NOT_NULL')
-        expect(result).to.equal('NOT_NULL')
-      })
+    test('applies a function to every item', async () => {
+      const result = deepMap(array, item => trim(item))
+      expect(result).to.equal(['a', 'b', 'c'])
+    })
+  })
+
+  experiment('when a string is provided', () => {
+    let string
+
+    before(() => {
+      string = ' abc '
     })
 
-    experiment('when a number is provided', () => {
-      test('leaves it as-is', () => {
-        const result = digitise.transformNulls(123)
-        expect(result).to.equal(123)
-      })
+    test('applies a function to it', async () => {
+      const result = deepMap(string, item => trim(item))
+      expect(result).to.equal('abc')
+    })
+  })
+
+  experiment('when a number is provided', () => {
+    let number
+
+    before(() => {
+      number = 123
     })
 
-    experiment('when a mixed array is provided', () => {
-      test('applies the correct transformation to each item', () => {
-        const result = digitise.transformNulls(['null', null, '', 'NOT_NULL'])
-        expect(result).to.equal([null, null, null, 'NOT_NULL'])
-      })
-    })
-
-    experiment('when an object is provided', () => {
-      test('applies the correct transformation to each item', () => {
-        const result = digitise.transformNulls({
-          notNulls: ['NOT_NULL', 'NOT_NULL_EITHER'],
-          nulls: [null, 'null', '']
-        })
-        expect(result).to.equal({
-          notNulls: ['NOT_NULL', 'NOT_NULL_EITHER'],
-          nulls: [null, null, null]
-        })
-      })
+    test('applies a function to it', async () => {
+      const result = deepMap(number, num => num * 2)
+      expect(result).to.equal(number * 2)
     })
   })
 })

--- a/test/digitise/index.test.js
+++ b/test/digitise/index.test.js
@@ -2,7 +2,8 @@
 
 const {
   experiment,
-  test
+  test,
+  before
 } = exports.lab = require('@hapi/lab').script()
 const { expect } = require('@hapi/code')
 
@@ -62,6 +63,47 @@ experiment('digitise/index.js', () => {
         expect(result).to.equal({
           notNulls: ['NOT_NULL', 'NOT_NULL_EITHER'],
           nulls: [null, null, null]
+        })
+      })
+    })
+  })
+
+  experiment('getWR22', () => {
+    experiment('when getWR22 is called', () => {
+      let wr22Data
+
+      before(async () => {
+        wr22Data = await digitise.getWR22()
+      })
+
+      test('returns an array of all json files', () => {
+        expect(wr22Data.length).to.equal(220)
+      })
+
+      test('returns the json data in the array', () => {
+        const [result] = wr22Data.filter(json => json.id === '/wr22/1.1')
+
+        expect(result).to.equal({
+          id: '/wr22/1.1',
+          type: 'object',
+          title: '1.1',
+          category: 'Minimum value condition',
+          subcategory: '',
+          description: 'The minimum value for the quantity of water authorised to be abstracted under this licence, as referred to in section 46(2A) Water Resources Act 1991, is [annual quantity] cubic metres per year.',
+          properties: {
+            nald_condition: {
+              $ref: 'water://licences/conditions.json',
+              label: 'NALD condition',
+              errors: {
+                required: {
+                  message: 'Select a NALD condition'
+                }
+              }
+            }
+          },
+          required: [
+            'nald_condition'
+          ]
         })
       })
     })

--- a/test/digitise/index.test.js
+++ b/test/digitise/index.test.js
@@ -1,78 +1,69 @@
 'use strict'
 
 const {
-  before,
   experiment,
   test
 } = exports.lab = require('@hapi/lab').script()
 const { expect } = require('@hapi/code')
-const { trim } = require('lodash')
 
 // Thing to test
-const deepMap = require('../../src/deep-map')
+const digitise = require('../../src/digitise')
 
-experiment('deep-map/index.js', () => {
-  experiment('when an object is provided', () => {
-    let object
-
-    before(() => {
-      object = {
-        a: ' a ',
-        b: {
-          b1: ' b1 ',
-          b2: ' b2 '
-        }
-      }
-    })
-
-    test('recursively applies a function to every item', async () => {
-      const result = deepMap(object, item => trim(item))
-      expect(result).to.equal({
-        a: 'a',
-        b: {
-          b1: 'b1',
-          b2: 'b2'
-        }
+experiment('digitise/index.js', () => {
+  experiment('transformNulls', () => {
+    experiment('when a string \'null\' is provided', () => {
+      test('transforms it to `null`', () => {
+        const result = digitise.transformNulls('null')
+        expect(result).to.be.null()
       })
     })
-  })
 
-  experiment('when an array is provided', () => {
-    let array
-
-    before(() => {
-      array = [' a ', ' b ', ' c ']
+    experiment('when an empty string is provided', () => {
+      test('transforms it to `null`', () => {
+        const result = digitise.transformNulls('')
+        expect(result).to.be.null()
+      })
     })
 
-    test('applies a function to every item', async () => {
-      const result = deepMap(array, item => trim(item))
-      expect(result).to.equal(['a', 'b', 'c'])
-    })
-  })
-
-  experiment('when a string is provided', () => {
-    let string
-
-    before(() => {
-      string = ' abc '
+    experiment('when `null` is provided', () => {
+      test('leaves it as `null`', () => {
+        const result = digitise.transformNulls(null)
+        expect(result).to.be.null()
+      })
     })
 
-    test('applies a function to it', async () => {
-      const result = deepMap(string, item => trim(item))
-      expect(result).to.equal('abc')
-    })
-  })
-
-  experiment('when a number is provided', () => {
-    let number
-
-    before(() => {
-      number = 123
+    experiment('when a regular string is provided', () => {
+      test('leaves it as-is', () => {
+        const result = digitise.transformNulls('NOT_NULL')
+        expect(result).to.equal('NOT_NULL')
+      })
     })
 
-    test('applies a function to it', async () => {
-      const result = deepMap(number, num => num * 2)
-      expect(result).to.equal(number * 2)
+    experiment('when a number is provided', () => {
+      test('leaves it as-is', () => {
+        const result = digitise.transformNulls(123)
+        expect(result).to.equal(123)
+      })
+    })
+
+    experiment('when a mixed array is provided', () => {
+      test('applies the correct transformation to each item', () => {
+        const result = digitise.transformNulls(['null', null, '', 'NOT_NULL'])
+        expect(result).to.equal([null, null, null, 'NOT_NULL'])
+      })
+    })
+
+    experiment('when an object is provided', () => {
+      test('applies the correct transformation to each item', () => {
+        const result = digitise.transformNulls({
+          notNulls: ['NOT_NULL', 'NOT_NULL_EITHER'],
+          nulls: [null, 'null', '']
+        })
+        expect(result).to.equal({
+          notNulls: ['NOT_NULL', 'NOT_NULL_EITHER'],
+          nulls: [null, null, null]
+        })
+      })
     })
   })
 })


### PR DESCRIPTION
We're pulling in the dependency `glob` but all we use it for is to read in an array of `*.json` filenames from a single folder, which is something we can easily do using native node functions. We therefore reimplement the `glob.sync` function and remove the dependency.