### PR TITLE
Reimplement `slugify` dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,6 @@
         "request": "^2.88.0",
         "request-promise-native": "^1.0.8",
         "shallow-diff": "0.0.5",
-        "slugify": "^1.6.0",
         "winston": "^2.4.4"
       },
       "devDependencies": {
@@ -4846,14 +4845,6 @@
       },
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/slugify": {
-      "version": "1.6.5",
-      "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.6.5.tgz",
-      "integrity": "sha512-8mo9bslnBO3tr5PEVFzMPIWwWnipGS0xVbYf65zxDqfNwmzYn1LpiKNrR6DlClusuvo+hDHd1zKpmfAe83NQSQ==",
-      "engines": {
-        "node": ">=8.0.0"
       }
     },
     "node_modules/snapdragon": {
@@ -10246,11 +10237,6 @@
         "astral-regex": "^1.0.0",
         "is-fullwidth-code-point": "^2.0.0"
       }
-    },
-    "slugify": {
-      "version": "1.6.5",
-      "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.6.5.tgz",
-      "integrity": "sha512-8mo9bslnBO3tr5PEVFzMPIWwWnipGS0xVbYf65zxDqfNwmzYn1LpiKNrR6DlClusuvo+hDHd1zKpmfAe83NQSQ=="
     },
     "snapdragon": {
       "version": "0.8.2",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "request": "^2.88.0",
     "request-promise-native": "^1.0.8",
     "shallow-diff": "0.0.5",
-    "slugify": "^1.6.0",
     "winston": "^2.4.4"
   },
   "devDependencies": {

--- a/src/digitise/schema-helpers.js
+++ b/src/digitise/schema-helpers.js
@@ -1,5 +1,4 @@
 const { find, flatMap } = require('lodash')
-// const slugify = require('slugify')
 
 // Structure of categories/subcats
 // [

--- a/src/digitise/schema-helpers.js
+++ b/src/digitise/schema-helpers.js
@@ -1,5 +1,5 @@
 const { find, flatMap } = require('lodash')
-const slugify = require('slugify')
+// const slugify = require('slugify')
 
 // Structure of categories/subcats
 // [
@@ -13,11 +13,44 @@ const slugify = require('slugify')
 //   }
 // ];
 
+/**
+ * Converts a string to a slug: strips out disallowed chars, replaces spaces with `-`, and converts to lower case.
+ *
+ * Based on https://www.npmjs.com/package/slugify
+ */
+const slugify = string => {
+  if (typeof string !== 'string') {
+    throw new Error('String argument expected')
+  }
+
+  return string
+    .normalize()
+    // Split our string into an array of individual characters so we can iterate over it using reduce
+    .split('')
+    .reduce((result, currentChar) => {
+      const appendChar = currentChar === '-'
+        // Later we will replace multiple spaces with a single `-`. We therefore treat `-` chars in our original string
+        // as spaces, so that something like `a - string` will gracefully collapse to just `a-string`
+        ? ' '
+        // Otherwise pass the current char through a regex which will change it to an empty string if it matches any of
+        // the disallowed chars we want to strip out
+        : currentChar.replace(/[^\w\s$*_+~.()'"!:@]+/g, '')
+
+      // Append our resulting character and go again
+      return result + appendChar
+    }, '')
+    // Trim whitespace and convert to lower case
+    .trim()
+    .toLowerCase()
+    // Replace all spaces with `-` (with consecutive spaces being replaced with a single `-`)
+    .replace(/\s+/g, '-')
+}
+
 const findByTitle = (arr, title) => find(arr, { title })
 
 const createCategory = schema => {
   const { category } = schema
-  const slug = slugify(category, { lower: true })
+  const slug = slugify(category)
   return {
     slug,
     title: category,

--- a/test/digitise/index.test.js
+++ b/test/digitise/index.test.js
@@ -108,4 +108,73 @@ experiment('digitise/index.js', () => {
       })
     })
   })
+
+  experiment('.getSchemaCategories', () => {
+    // Array of simplified schema, containing just a category name (taken from the current set of schema JSON files)
+    const schemaArray = [
+      { category: 'Minimum value condition' },
+      { category: 'Hands off flows/levels' },
+      { category: 'Augmentation and Compensation conditions' },
+      { category: 'Flow/level measurement devices' },
+      { category: 'Construction and notices' },
+      { category: 'Ongoing measurement and maintenance' },
+      { category: 'Recording' },
+      { category: 'Storage conditions' },
+      { category: 'Time Limiting - abstractions start' },
+      { category: 'Chemical conditions' },
+      { category: 'Land on which licence authorises use of water' },
+      { category: 'Point at which water must be returned' },
+      { category: 'Temporary licence provision' },
+      { category: 'Groundwater conditions' },
+      { category: 'Ground source heating and cooling pumps' },
+      { category: 'Screening' },
+      { category: 'Fish and Eel passage' },
+      { category: 'Hydropower' },
+      { category: 'Impounding conditions' },
+      { category: 'Obstructing or impeding the flow of an inland water' },
+      { category: 'Removal of impounding works' },
+      { category: 'Water Rights Trading' },
+      { category: 'Environmental monitoring' },
+      { category: 'Control on abstraction' },
+      { category: 'Derogation Agreement' }
+    ]
+
+    // What the slugs should be for the categories, based on passing them through the slugify npm package
+    const slugArray = [
+      'minimum-value-condition',
+      'hands-off-flowslevels',
+      'augmentation-and-compensation-conditions',
+      'flowlevel-measurement-devices',
+      'construction-and-notices',
+      'ongoing-measurement-and-maintenance',
+      'recording',
+      'storage-conditions',
+      'time-limiting-abstractions-start',
+      'chemical-conditions',
+      'land-on-which-licence-authorises-use-of-water',
+      'point-at-which-water-must-be-returned',
+      'temporary-licence-provision',
+      'groundwater-conditions',
+      'ground-source-heating-and-cooling-pumps',
+      'screening',
+      'fish-and-eel-passage',
+      'hydropower',
+      'impounding-conditions',
+      'obstructing-or-impeding-the-flow-of-an-inland-water',
+      'removal-of-impounding-works',
+      'water-rights-trading',
+      'environmental-monitoring',
+      'control-on-abstraction',
+      'derogation-agreement'
+    ]
+
+    test('correctly generates slugs based on the schema categories', () => {
+      const categories = digitise.getSchemaCategories(schemaArray)
+
+      // Pull all category slugs out into an array for easier testing
+      const slugs = categories.map(category => category.slug)
+
+      expect(slugs).to.contain(slugArray)
+    })
+  })
 })

--- a/test/digitise/index.test.js
+++ b/test/digitise/index.test.js
@@ -139,8 +139,10 @@ experiment('digitise/index.js', () => {
       { category: 'Derogation Agreement' }
     ]
 
-    // What the slugs should be for the categories, based on passing them through the slugify npm package
-    const slugArray = [
+    // What the slugs should be for the categories, based on passing the category strings through the slugify package we
+    // previously used. We check that we match our existing slugs to ensure our reimplementation is fully compatible
+    // with our previous use of slugify.
+    const expectedSlugArray = [
       'minimum-value-condition',
       'hands-off-flowslevels',
       'augmentation-and-compensation-conditions',
@@ -174,7 +176,7 @@ experiment('digitise/index.js', () => {
       // Pull all category slugs out into an array for easier testing
       const slugs = categories.map(category => category.slug)
 
-      expect(slugs).to.contain(slugArray)
+      expect(slugs).to.contain(expectedSlugArray)
     })
   })
 })


### PR DESCRIPTION
We're pulling in the dependency `slugify` which we use in one place, to convert schema category names into slugs. To reduce our reliance on external dependencies we reimplement `slugify` ourselves, using its code as a guide.