### PR TITLE
Handle Stacktrace only errors

### DIFF
--- a/src/logger/index.js
+++ b/src/logger/index.js
@@ -105,10 +105,23 @@ const getFilename = () => {
  */
 const proxyLoggerError = logger => {
   const errorProxy = logger.error
-  logger.error = (msg, error, params) => {
-    const err = decorateError(error, params)
+  logger.error = (msg, error, params = {}) => {
+    const parsedError = parseError(error)
+    const err = decorateError(parsedError, params)
     errorProxy(msg, err)
   }
+}
+
+const parseError = (error) => {
+  let parsedError = {}
+
+  if (typeof error === 'string') {
+    parsedError.stack = error
+  } else {
+    parsedError = error
+  }
+
+  return parsedError
 }
 
 const initAirbrakeLogger = (logger, options) => {

--- a/src/logger/index.js
+++ b/src/logger/index.js
@@ -50,7 +50,7 @@ const decorateError = (error, params) => {
  * @param {string} line A line from the stack trace
  * @returns {string} Only the content in the parentheses
  */
-const getContentInParentheses = line => {
+const getContentInParentheses = (line) => {
   if (line.indexOf('(') > -1) {
     return get(inParensRegex.exec(line), '[1]')
   }
@@ -72,11 +72,11 @@ const getContentAfter = (errorLine = '', after) => {
     : errorLine.substring(index + after.length)
 }
 
-const isLineFromThisFile = line => line.indexOf(__filename) > -1
+const isLineFromThisFile = (line) => line.indexOf(__filename) > -1
 
 const getStackLines = () => (new Error()).stack.split('\n')
 
-const findCallingFile = stackLines => {
+const findCallingFile = (stackLines) => {
   // Remove first line (Error: 'Message')
   const lines = stackLines.slice(1)
 
@@ -103,7 +103,7 @@ const getFilename = () => {
  * Creates a proxy onto logger.error that adds additional behaviour to
  * augment the error object with Errbit specific properties.
  */
-const proxyLoggerError = logger => {
+const proxyLoggerError = (logger) => {
   const errorProxy = logger.error
   logger.error = (msg, error, params = {}) => {
     const parsedError = parseError(error)

--- a/src/logger/index.js
+++ b/src/logger/index.js
@@ -112,7 +112,7 @@ const proxyLoggerError = (logger) => {
   }
 }
 
-const parseError = (error) => {
+function parseError (error) {
   let parsedError = {}
 
   if (typeof error === 'string') {

--- a/test/logger/index.test.js
+++ b/test/logger/index.test.js
@@ -27,33 +27,66 @@ experiment('Test logger', () => {
     logger.on('logged', spy)
   })
 
-  test('It should log an error to the console', async () => {
-    logger.log('error', 'A test')
-    const [level, message, data] = spy.firstCall.args
-    expect(level).to.equal('error')
-    expect(message).to.equal('A test')
-    expect(data).to.equal({})
+  experiment('when the type of message is passed to logger.log()', () => {
+    test('It should log an error to the console', async () => {
+      logger.log('error', 'A test')
+      const [level, message, data] = spy.firstCall.args
+      expect(level).to.equal('error')
+      expect(message).to.equal('A test')
+      expect(data).to.equal({})
+    })
+
+    test('It should log an info level message to the console', async () => {
+      logger.log('info', 'A test')
+      const [level, message, data] = spy.firstCall.args
+      expect(level).to.equal('info')
+      expect(message).to.equal('A test')
+      expect(data).to.equal({})
+    })
+
+    test('It should log a warning level message to the console', async () => {
+      logger.log('warn', 'A test')
+      const [level, message, data] = spy.firstCall.args
+      expect(level).to.equal('warn')
+      expect(message).to.equal('A test')
+      expect(data).to.equal({})
+    })
+
+    test('It should not log debug message - below the minimum logging level', async () => {
+      logger.log('debug', 'A test')
+      expect(spy.firstCall).to.equal(null)
+    })
   })
 
-  test('It should log an info level message to the console', async () => {
-    logger.log('info', 'A test')
-    const [level, message, data] = spy.firstCall.args
-    expect(level).to.equal('info')
-    expect(message).to.equal('A test')
-    expect(data).to.equal({})
-  })
+  experiment('when the type of message is set by calling the method on the logger', () => {
+    test('It should log an error to the console', async () => {
+      logger.error('A test')
+      const [level, message, data] = spy.firstCall.args
+      expect(level).to.equal('error')
+      expect(message).to.equal('A test')
+      expect(data).to.equal({})
+    })
 
-  test('It should log a warning level message to the console', async () => {
-    logger.log('warn', 'A test')
-    const [level, message, data] = spy.firstCall.args
-    expect(level).to.equal('warn')
-    expect(message).to.equal('A test')
-    expect(data).to.equal({})
-  })
+    test('It should log an info level message to the console', async () => {
+      logger.info('A test')
+      const [level, message, data] = spy.firstCall.args
+      expect(level).to.equal('info')
+      expect(message).to.equal('A test')
+      expect(data).to.equal({})
+    })
 
-  test('It should not log debug message - below the minimum logging level', async () => {
-    logger.log('debug', 'A test')
-    expect(spy.firstCall).to.equal(null)
+    test('It should log a warning level message to the console', async () => {
+      logger.warn('A test')
+      const [level, message, data] = spy.firstCall.args
+      expect(level).to.equal('warn')
+      expect(message).to.equal('A test')
+      expect(data).to.equal({})
+    })
+
+    test('It should not log debug message - below the minimum logging level', async () => {
+      logger.debug('A test')
+      expect(spy.firstCall).to.equal(null)
+    })
   })
 })
 

--- a/test/logger/index.test.js
+++ b/test/logger/index.test.js
@@ -59,14 +59,6 @@ experiment('Test logger', () => {
   })
 
   experiment('when the type of message is set by calling the method on the logger', () => {
-    test('It should log an error to the console', async () => {
-      logger.error('A test')
-      const [level, message, data] = spy.firstCall.args
-      expect(level).to.equal('error')
-      expect(message).to.equal('A test')
-      expect(data).to.equal({})
-    })
-
     test('It should log an info level message to the console', async () => {
       logger.info('A test')
       const [level, message, data] = spy.firstCall.args
@@ -86,6 +78,51 @@ experiment('Test logger', () => {
     test('It should not log debug message - below the minimum logging level', async () => {
       logger.debug('A test')
       expect(spy.firstCall).to.equal(null)
+    })
+
+    experiment('and we are logging an error', () => {
+      experiment('but we do not pass an error', () => {
+        test('It should log an error to the console', async () => {
+          logger.error('A test')
+          const [level, message, data] = spy.firstCall.args
+
+          expect(level).to.equal('error')
+          expect(message).to.equal('A test')
+          expect(data).to.equal(undefined)
+        })
+      })
+
+      experiment('and we pass a stacktrace (string) as the error', () => {
+        test('It should log an error to the console', async () => {
+          logger.error('A test', 'It failed at this point in the code')
+          const [level, message, data] = spy.firstCall.args
+
+          expect(level).to.equal('error')
+          expect(message).to.equal('A test')
+          expect(data).to.equal({
+            stack: 'It failed at this point in the code',
+            context: { component: '/logger/index.test.js:97:18' },
+            params: {}
+          })
+        })
+      })
+
+      experiment('and we pass an instance of Error as the error', () => {
+        test('It should log an error to the console', async () => {
+          // Pass our error undecorated
+          const testError = new Error('It failed')
+          logger.error('A test', testError)
+
+          // then decorate it in the same way the code will
+          const deoratedError = decorateError(testError, {})
+
+          const [level, message, data] = spy.firstCall.args
+
+          expect(level).to.equal('error')
+          expect(message).to.equal('A test')
+          expect(data).to.equal(deoratedError)
+        })
+      })
     })
   })
 })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-3845
https://github.com/DEFRA/water-abstraction-team/issues/45

We recently made a change to stop the madness of our logs getting jammed with the whole app codebase getting dumped every time there was an error. All appeared good until an issue was raised when users attempted to cancel a bill run.

_Taken from [water-abstraction-service - src/modules/billing/services/batch-service.js](https://github.com/DEFRA/water-abstraction-service)_
```javascript
const deleteBatch = async (batch, internalCallingUser) => {
  if (!batch.canBeDeleted()) {
    throw new BatchStatusError(`Batch ${batch.id} cannot be deleted - status is ${batch.status}`)
  }

  try {
    await chargeModuleBillRunConnector.delete(batch.externalId)

    // These are populated at every stage in the bill run
    await newRepos.billingBatchChargeVersionYears.deleteByBatchId(batch.id, false)
    await newRepos.billingVolumes.deleteByBatchId(batch.id)

    // These tables are not yet populated at review stage in TPT
    await newRepos.billingTransactions.deleteByBatchId(batch.id)
    await newRepos.billingInvoiceLicences.deleteByBatchId(batch.id)
    await newRepos.billingInvoices.deleteByBatchId(batch.id, false)
    await newRepos.billingBatches.delete(batch.id)

    await saveEvent('billing-batch:cancel', 'delete', internalCallingUser, batch)
  } catch (err) {
    logger.error('Failed to delete the batch', err.stack, batch)
    await saveEvent('billing-batch:cancel', 'error', internalCallingUser, batch)
    await setStatus(batch.id, BATCH_STATUS.error)
    throw err
  }
}
```

From looking at the logs it seems our request to the charging module API to delete the bill run is not being handled gracefully. If there are any authentication issues, for example, the Cognito token has expired, it gets into a mess. The bill run does get deleted in the CHA, but we also seem to go into a cycle of retrying. This will cause the CHA API to return a `4xx` which then causes an exception to be thrown on the WRLS side.

From looking at the data this isn't the first time it's happened. But previously the batch would get flagged as errored after the failure had been logged (who cares about deleting the data!😜). In this case, the logger code in this repo is expecting an error object and is throwing an error when it doesn't get one. This goes all the way to the top, causing the event and status updates to never get called in the above code.

We're not going back (we only tracked this down _because_ the logs are now approaching being usable). But we need to make a change to cater for this scenario.