### PR TITLE
Add post version bump CHANGELOG hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
   },
   "scripts": {
     "test": "lab",
-    "lint": "standard"
+    "lint": "standard",
+    "version": "npx --yes auto-changelog -p --commit-limit false && git add CHANGELOG.md"
   },
   "dependencies": {
     "airbrake-js": "^1.6.8",


### PR DESCRIPTION
https://github.com/DEFRA/water-abstraction-team/issues/59

In all our repos we need to bump versions, generate CHANGELOG files, create tags and mark releases. This applies to the helpers as well, but it seems it doesn't have the support the other repos have.

To bump a node project you can run `npm version`. This bumps the version in the `package.json` as well as the `package-lock.json`. It also generates the correct git tag. It also means we can just decide the change type (major, minor or patch) and let npm work out the bump. That way we're less likely to make a mistake.

If you add a script in named `version:` npm will automatically run it after you have called `npm version`. It's here our other repos update the CHANGELOG.md automatically. This change updates the helpers to have the same hook.

So now our process when generating a new helpers release will be

- decide on the change type
- run `npm version [major|minor|patch]`
- check the changes
- push the commit

Much simpler as we don't need to be specific with version numbers.