### PR TITLE
Update packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
       "devDependencies": {
         "@hapi/code": "^9.0.3",
         "@hapi/hapi": "^21.3.9",
-        "@hapi/lab": "^25.0.1",
+        "@hapi/lab": "^25.2.0",
         "auto-changelog": "^1.16.4",
         "dotenv": "^16.0.2",
         "sinon": "^7.5.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "@hapi/hapi": "^21.3.9",
         "@hapi/lab": "^25.2.0",
         "auto-changelog": "^1.16.4",
-        "dotenv": "^16.0.2",
+        "dotenv": "^16.4.5",
         "sinon": "^7.5.0",
         "standard": "^17.1.0"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "winston": "^2.4.6"
       },
       "devDependencies": {
-        "@hapi/code": "^9.0.1",
+        "@hapi/code": "^9.0.3",
         "@hapi/hapi": "^21.3.2",
         "@hapi/lab": "^25.0.1",
         "auto-changelog": "^1.16.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "@hapi/code": "^9.0.3",
         "@hapi/hapi": "^21.3.9",
         "@hapi/lab": "^25.2.0",
-        "auto-changelog": "^1.16.4",
+        "auto-changelog": "^2.4.0",
         "dotenv": "^16.4.5",
         "sinon": "^7.5.0",
         "standard": "^17.1.0"
@@ -1404,21 +1404,34 @@
       "license": "MIT"
     },
     "node_modules/auto-changelog": {
-      "version": "1.16.4",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/auto-changelog/-/auto-changelog-2.4.0.tgz",
+      "integrity": "sha512-vh17hko1c0ItsEcw6m7qPRf3m45u+XK5QyCrrBFViElZ8jnKrPC1roSznrd1fIB/0vR/zawdECCRJtTuqIXaJw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "commander": "^5.0.0",
-        "core-js": "^3.6.4",
-        "handlebars": "^4.7.3",
-        "lodash.uniqby": "^4.7.0",
-        "node-fetch": "^2.6.0",
+        "commander": "^7.2.0",
+        "handlebars": "^4.7.7",
+        "node-fetch": "^2.6.1",
         "parse-github-url": "^1.0.2",
-        "regenerator-runtime": "^0.13.5",
-        "semver": "^6.3.0"
+        "semver": "^7.3.5"
       },
       "bin": {
-        "auto-changelog": "lib/index.js"
+        "auto-changelog": "src/index.js"
+      },
+      "engines": {
+        "node": ">=8.3"
+      }
+    },
+    "node_modules/auto-changelog/node_modules/semver": {
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
+      "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/available-typed-arrays": {
@@ -1634,11 +1647,12 @@
       }
     },
     "node_modules/commander": {
-      "version": "5.1.0",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
       "dev": true,
-      "license": "MIT",
       "engines": {
-        "node": ">= 6"
+        "node": ">= 10"
       }
     },
     "node_modules/concat-map": {
@@ -1660,16 +1674,6 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "dev": true
-    },
-    "node_modules/core-js": {
-      "version": "3.23.3",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/core-js"
-      }
     },
     "node_modules/core-util-is": {
       "version": "1.0.2",
@@ -3632,11 +3636,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/lodash.uniqby": {
-      "version": "4.7.0",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/lolex": {
       "version": "4.2.0",
       "dev": true,
@@ -4376,11 +4375,6 @@
     },
     "node_modules/react-is": {
       "version": "16.13.1",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/regenerator-runtime": {
-      "version": "0.13.9",
       "dev": true,
       "license": "MIT"
     },
@@ -6501,17 +6495,24 @@
       "version": "0.4.0"
     },
     "auto-changelog": {
-      "version": "1.16.4",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/auto-changelog/-/auto-changelog-2.4.0.tgz",
+      "integrity": "sha512-vh17hko1c0ItsEcw6m7qPRf3m45u+XK5QyCrrBFViElZ8jnKrPC1roSznrd1fIB/0vR/zawdECCRJtTuqIXaJw==",
       "dev": true,
       "requires": {
-        "commander": "^5.0.0",
-        "core-js": "^3.6.4",
-        "handlebars": "^4.7.3",
-        "lodash.uniqby": "^4.7.0",
-        "node-fetch": "^2.6.0",
+        "commander": "^7.2.0",
+        "handlebars": "^4.7.7",
+        "node-fetch": "^2.6.1",
         "parse-github-url": "^1.0.2",
-        "regenerator-runtime": "^0.13.5",
-        "semver": "^6.3.0"
+        "semver": "^7.3.5"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "7.6.2",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
+          "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
+          "dev": true
+        }
       }
     },
     "available-typed-arrays": {
@@ -6659,7 +6660,9 @@
       }
     },
     "commander": {
-      "version": "5.1.0",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
       "dev": true
     },
     "concat-map": {
@@ -6682,10 +6685,6 @@
           "dev": true
         }
       }
-    },
-    "core-js": {
-      "version": "3.23.3",
-      "dev": true
     },
     "core-util-is": {
       "version": "1.0.2"
@@ -8076,10 +8075,6 @@
       "version": "4.6.2",
       "dev": true
     },
-    "lodash.uniqby": {
-      "version": "4.7.0",
-      "dev": true
-    },
     "lolex": {
       "version": "4.2.0",
       "dev": true
@@ -8571,10 +8566,6 @@
     },
     "react-is": {
       "version": "16.13.1",
-      "dev": true
-    },
-    "regenerator-runtime": {
-      "version": "0.13.9",
       "dev": true
     },
     "regexp.prototype.flags": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
       },
       "devDependencies": {
         "@hapi/code": "^9.0.3",
-        "@hapi/hapi": "^21.3.2",
+        "@hapi/hapi": "^21.3.9",
         "@hapi/lab": "^25.0.1",
         "auto-changelog": "^1.16.4",
         "dotenv": "^16.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "OGL-UK-3.0",
       "dependencies": {
         "airbrake-js": "^1.6.8",
-        "cross-fetch": "^3.1.5",
+        "cross-fetch": "^4.0.0",
         "immutability-helper": "^3.1.1",
         "joi": "^17.6.2",
         "lodash": "^4.17.21",
@@ -1676,9 +1676,9 @@
       "license": "MIT"
     },
     "node_modules/cross-fetch": {
-      "version": "3.1.8",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.8.tgz",
-      "integrity": "sha512-cvA+JwZoU0Xq+h6WkMvAUqPEYy92Obet6UdKLfW60qn99ftItKjB5T+BkyWOFWe2pUyfQ+IJHmpOTznqk1M6Kg==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-4.0.0.tgz",
+      "integrity": "sha512-e4a5N8lVvuLgAWgnCrLr2PP0YyDOTHa9H/Rj54dirp61qXnNq46m82bRhNqIA5VccJtWBvPTFRV3TtvHUKPB1g==",
       "dependencies": {
         "node-fetch": "^2.6.12"
       }
@@ -6691,9 +6691,9 @@
       "version": "1.0.2"
     },
     "cross-fetch": {
-      "version": "3.1.8",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.8.tgz",
-      "integrity": "sha512-cvA+JwZoU0Xq+h6WkMvAUqPEYy92Obet6UdKLfW60qn99ftItKjB5T+BkyWOFWe2pUyfQ+IJHmpOTznqk1M6Kg==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-4.0.0.tgz",
+      "integrity": "sha512-e4a5N8lVvuLgAWgnCrLr2PP0YyDOTHa9H/Rj54dirp61qXnNq46m82bRhNqIA5VccJtWBvPTFRV3TtvHUKPB1g==",
       "requires": {
         "node-fetch": "^2.6.12"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "airbrake-js": "^1.6.8",
         "cross-fetch": "^4.0.0",
         "immutability-helper": "^3.1.1",
-        "joi": "^17.6.2",
+        "joi": "^17.13.1",
         "lodash": "^4.17.21",
         "moment": "^2.29.4",
         "moment-range": "^4.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "immutability-helper": "^3.1.1",
         "joi": "^17.13.1",
         "lodash": "^4.17.21",
-        "moment": "^2.29.4",
+        "moment": "^2.30.1",
         "moment-range": "^4.0.2",
         "pg": "^8.8.0",
         "request": "^2.88.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "@hapi/lab": "^25.2.0",
         "auto-changelog": "^2.4.0",
         "dotenv": "^16.4.5",
-        "sinon": "^7.5.0",
+        "sinon": "^18.0.0",
         "standard": "^17.1.0"
       }
     },
@@ -1176,36 +1176,48 @@
       "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ=="
     },
     "node_modules/@sinonjs/commons": {
-      "version": "1.8.3",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
+      "integrity": "sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==",
       "dev": true,
-      "license": "BSD-3-Clause",
       "dependencies": {
         "type-detect": "4.0.8"
       }
     },
-    "node_modules/@sinonjs/formatio": {
-      "version": "3.2.2",
+    "node_modules/@sinonjs/fake-timers": {
+      "version": "11.2.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-11.2.2.tgz",
+      "integrity": "sha512-G2piCSxQ7oWOxwGSAyFHfPIsyeJGXYtc6mFbnFA+kRXkiEnTl8c/8jul2S329iFBnDI9HGoeWWAZvuvOkZccgw==",
       "dev": true,
-      "license": "BSD-3-Clause",
       "dependencies": {
-        "@sinonjs/commons": "^1",
-        "@sinonjs/samsam": "^3.1.0"
+        "@sinonjs/commons": "^3.0.0"
       }
     },
     "node_modules/@sinonjs/samsam": {
-      "version": "3.3.3",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-8.0.0.tgz",
+      "integrity": "sha512-Bp8KUVlLp8ibJZrnvq2foVhP0IVX2CIprMJPK0vqGqgrDa0OHVKeZyBykqskkrdxV6yKBPmGasO8LVjAKR3Gew==",
       "dev": true,
-      "license": "BSD-3-Clause",
       "dependencies": {
-        "@sinonjs/commons": "^1.3.0",
-        "array-from": "^2.1.1",
-        "lodash": "^4.17.15"
+        "@sinonjs/commons": "^2.0.0",
+        "lodash.get": "^4.4.2",
+        "type-detect": "^4.0.8"
+      }
+    },
+    "node_modules/@sinonjs/samsam/node_modules/@sinonjs/commons": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-2.0.0.tgz",
+      "integrity": "sha512-uLa0j859mMrg2slwQYdO/AkrOfmH+X6LTVmNTS9CqexuE2IvVORIkSpJLqePAbEnKJ77aMmCwr1NUZ57120Xcg==",
+      "dev": true,
+      "dependencies": {
+        "type-detect": "4.0.8"
       }
     },
     "node_modules/@sinonjs/text-encoding": {
-      "version": "0.7.1",
-      "dev": true,
-      "license": "(Unlicense OR Apache-2.0)"
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.2.tgz",
+      "integrity": "sha512-sXXKG+uL9IrKqViTtao2Ws6dy0znu9sOaP1di/jKGW1M6VssO8vlpXCQcpZ+jisQ1tTFAC5Jo/EOzFbggBagFQ==",
+      "dev": true
     },
     "node_modules/@types/json5": {
       "version": "0.0.29",
@@ -1294,11 +1306,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/array-from": {
-      "version": "2.1.1",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/array-includes": {
       "version": "3.1.6",
@@ -1771,9 +1778,9 @@
       }
     },
     "node_modules/diff": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-5.1.0.tgz",
-      "integrity": "sha512-D+mk+qE8VC/PAUrlAU34N+VfXev0ghe5ywmpqrawphmVZc1bEfn56uo9qpyGp1p4xpzOHkSW4ztBd6L7Xx4ACw==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.0.tgz",
+      "integrity": "sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==",
       "dev": true,
       "engines": {
         "node": ">=0.3.1"
@@ -3470,11 +3477,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/isarray": {
-      "version": "0.0.1",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -3595,9 +3597,10 @@
       }
     },
     "node_modules/just-extend": {
-      "version": "4.2.1",
-      "dev": true,
-      "license": "MIT"
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-6.2.0.tgz",
+      "integrity": "sha512-cYofQu2Xpom82S6qD778jBDpwvvy39s1l/hrYij2u9AMdQcGRpaBu6kY4mVhuno5kJVi1DAz4aiphA2WI1/OAw==",
+      "dev": true
     },
     "node_modules/levn": {
       "version": "0.4.1",
@@ -3631,15 +3634,16 @@
       "version": "4.17.21",
       "license": "MIT"
     },
+    "node_modules/lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
+      "dev": true
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/lolex": {
-      "version": "4.2.0",
-      "dev": true,
-      "license": "BSD-3-Clause"
     },
     "node_modules/loose-envify": {
       "version": "1.4.0",
@@ -3772,23 +3776,16 @@
       "license": "ISC"
     },
     "node_modules/nise": {
-      "version": "1.5.3",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-6.0.0.tgz",
+      "integrity": "sha512-K8ePqo9BFvN31HXwEtTNGzgrPpmvgciDsFz8aztFjt4LqKO/JeFD8tBOeuDiCMXrIl/m1YvfH8auSpxfaD09wg==",
       "dev": true,
-      "license": "BSD-3-Clause",
       "dependencies": {
-        "@sinonjs/formatio": "^3.2.1",
-        "@sinonjs/text-encoding": "^0.7.1",
-        "just-extend": "^4.0.2",
-        "lolex": "^5.0.1",
-        "path-to-regexp": "^1.7.0"
-      }
-    },
-    "node_modules/nise/node_modules/lolex": {
-      "version": "5.1.2",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@sinonjs/commons": "^1.7.0"
+        "@sinonjs/commons": "^3.0.0",
+        "@sinonjs/fake-timers": "^11.2.2",
+        "@sinonjs/text-encoding": "^0.7.2",
+        "just-extend": "^6.2.0",
+        "path-to-regexp": "^6.2.1"
       }
     },
     "node_modules/node-fetch": {
@@ -4020,12 +4017,10 @@
       "license": "MIT"
     },
     "node_modules/path-to-regexp": {
-      "version": "1.8.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "isarray": "0.0.1"
-      }
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.2.tgz",
+      "integrity": "sha512-GQX3SSMokngb36+whdpRXE+3f9V8UzyAorlYvOGx87ufGHehNTn5lCxrKtLyZ4Yl/wEKnNnr98ZzOwwDZV5ogw==",
+      "dev": true
     },
     "node_modules/path-type": {
       "version": "4.0.0",
@@ -4624,36 +4619,42 @@
       }
     },
     "node_modules/sinon": {
-      "version": "7.5.0",
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-18.0.0.tgz",
+      "integrity": "sha512-+dXDXzD1sBO6HlmZDd7mXZCR/y5ECiEiGCBSGuFD/kZ0bDTofPYc6JaeGmPSF+1j1MejGUWkORbYOLDyvqCWpA==",
       "dev": true,
-      "license": "BSD-3-Clause",
       "dependencies": {
-        "@sinonjs/commons": "^1.4.0",
-        "@sinonjs/formatio": "^3.2.1",
-        "@sinonjs/samsam": "^3.3.3",
-        "diff": "^3.5.0",
-        "lolex": "^4.2.0",
-        "nise": "^1.5.2",
-        "supports-color": "^5.5.0"
+        "@sinonjs/commons": "^3.0.1",
+        "@sinonjs/fake-timers": "^11.2.2",
+        "@sinonjs/samsam": "^8.0.0",
+        "diff": "^5.2.0",
+        "nise": "^6.0.0",
+        "supports-color": "^7"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/sinon"
       }
     },
-    "node_modules/sinon/node_modules/diff": {
-      "version": "3.5.0",
+    "node_modules/sinon/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "dev": true,
-      "license": "BSD-3-Clause",
       "engines": {
-        "node": ">=0.3.1"
+        "node": ">=8"
       }
     },
     "node_modules/sinon/node_modules/supports-color": {
-      "version": "5.5.0",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "has-flag": "^3.0.0"
+        "has-flag": "^4.0.0"
       },
       "engines": {
-        "node": ">=4"
+        "node": ">=8"
       }
     },
     "node_modules/slash": {
@@ -5038,8 +5039,9 @@
     },
     "node_modules/type-detect": {
       "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=4"
       }
@@ -6324,31 +6326,49 @@
       "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ=="
     },
     "@sinonjs/commons": {
-      "version": "1.8.3",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
+      "integrity": "sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==",
       "dev": true,
       "requires": {
         "type-detect": "4.0.8"
       }
     },
-    "@sinonjs/formatio": {
-      "version": "3.2.2",
+    "@sinonjs/fake-timers": {
+      "version": "11.2.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-11.2.2.tgz",
+      "integrity": "sha512-G2piCSxQ7oWOxwGSAyFHfPIsyeJGXYtc6mFbnFA+kRXkiEnTl8c/8jul2S329iFBnDI9HGoeWWAZvuvOkZccgw==",
       "dev": true,
       "requires": {
-        "@sinonjs/commons": "^1",
-        "@sinonjs/samsam": "^3.1.0"
+        "@sinonjs/commons": "^3.0.0"
       }
     },
     "@sinonjs/samsam": {
-      "version": "3.3.3",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-8.0.0.tgz",
+      "integrity": "sha512-Bp8KUVlLp8ibJZrnvq2foVhP0IVX2CIprMJPK0vqGqgrDa0OHVKeZyBykqskkrdxV6yKBPmGasO8LVjAKR3Gew==",
       "dev": true,
       "requires": {
-        "@sinonjs/commons": "^1.3.0",
-        "array-from": "^2.1.1",
-        "lodash": "^4.17.15"
+        "@sinonjs/commons": "^2.0.0",
+        "lodash.get": "^4.4.2",
+        "type-detect": "^4.0.8"
+      },
+      "dependencies": {
+        "@sinonjs/commons": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-2.0.0.tgz",
+          "integrity": "sha512-uLa0j859mMrg2slwQYdO/AkrOfmH+X6LTVmNTS9CqexuE2IvVORIkSpJLqePAbEnKJ77aMmCwr1NUZ57120Xcg==",
+          "dev": true,
+          "requires": {
+            "type-detect": "4.0.8"
+          }
+        }
       }
     },
     "@sinonjs/text-encoding": {
-      "version": "0.7.1",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.2.tgz",
+      "integrity": "sha512-sXXKG+uL9IrKqViTtao2Ws6dy0znu9sOaP1di/jKGW1M6VssO8vlpXCQcpZ+jisQ1tTFAC5Jo/EOzFbggBagFQ==",
       "dev": true
     },
     "@types/json5": {
@@ -6413,10 +6433,6 @@
         "call-bind": "^1.0.2",
         "is-array-buffer": "^3.0.1"
       }
-    },
-    "array-from": {
-      "version": "2.1.1",
-      "dev": true
     },
     "array-includes": {
       "version": "3.1.6",
@@ -6751,9 +6767,9 @@
       "version": "1.0.0"
     },
     "diff": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-5.1.0.tgz",
-      "integrity": "sha512-D+mk+qE8VC/PAUrlAU34N+VfXev0ghe5ywmpqrawphmVZc1bEfn56uo9qpyGp1p4xpzOHkSW4ztBd6L7Xx4ACw==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.0.tgz",
+      "integrity": "sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==",
       "dev": true
     },
     "dir-glob": {
@@ -7946,10 +7962,6 @@
         "call-bind": "^1.0.2"
       }
     },
-    "isarray": {
-      "version": "0.0.1",
-      "dev": true
-    },
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -8044,7 +8056,9 @@
       }
     },
     "just-extend": {
-      "version": "4.2.1",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-6.2.0.tgz",
+      "integrity": "sha512-cYofQu2Xpom82S6qD778jBDpwvvy39s1l/hrYij2u9AMdQcGRpaBu6kY4mVhuno5kJVi1DAz4aiphA2WI1/OAw==",
       "dev": true
     },
     "levn": {
@@ -8071,12 +8085,14 @@
     "lodash": {
       "version": "4.17.21"
     },
-    "lodash.merge": {
-      "version": "4.6.2",
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
       "dev": true
     },
-    "lolex": {
-      "version": "4.2.0",
+    "lodash.merge": {
+      "version": "4.6.2",
       "dev": true
     },
     "loose-envify": {
@@ -8167,23 +8183,16 @@
       "version": "1.1.0"
     },
     "nise": {
-      "version": "1.5.3",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-6.0.0.tgz",
+      "integrity": "sha512-K8ePqo9BFvN31HXwEtTNGzgrPpmvgciDsFz8aztFjt4LqKO/JeFD8tBOeuDiCMXrIl/m1YvfH8auSpxfaD09wg==",
       "dev": true,
       "requires": {
-        "@sinonjs/formatio": "^3.2.1",
-        "@sinonjs/text-encoding": "^0.7.1",
-        "just-extend": "^4.0.2",
-        "lolex": "^5.0.1",
-        "path-to-regexp": "^1.7.0"
-      },
-      "dependencies": {
-        "lolex": {
-          "version": "5.1.2",
-          "dev": true,
-          "requires": {
-            "@sinonjs/commons": "^1.7.0"
-          }
-        }
+        "@sinonjs/commons": "^3.0.0",
+        "@sinonjs/fake-timers": "^11.2.2",
+        "@sinonjs/text-encoding": "^0.7.2",
+        "just-extend": "^6.2.0",
+        "path-to-regexp": "^6.2.1"
       }
     },
     "node-fetch": {
@@ -8337,11 +8346,10 @@
       "dev": true
     },
     "path-to-regexp": {
-      "version": "1.8.0",
-      "dev": true,
-      "requires": {
-        "isarray": "0.0.1"
-      }
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.2.tgz",
+      "integrity": "sha512-GQX3SSMokngb36+whdpRXE+3f9V8UzyAorlYvOGx87ufGHehNTn5lCxrKtLyZ4Yl/wEKnNnr98ZzOwwDZV5ogw==",
+      "dev": true
     },
     "path-type": {
       "version": "4.0.0",
@@ -8719,27 +8727,32 @@
       }
     },
     "sinon": {
-      "version": "7.5.0",
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-18.0.0.tgz",
+      "integrity": "sha512-+dXDXzD1sBO6HlmZDd7mXZCR/y5ECiEiGCBSGuFD/kZ0bDTofPYc6JaeGmPSF+1j1MejGUWkORbYOLDyvqCWpA==",
       "dev": true,
       "requires": {
-        "@sinonjs/commons": "^1.4.0",
-        "@sinonjs/formatio": "^3.2.1",
-        "@sinonjs/samsam": "^3.3.3",
-        "diff": "^3.5.0",
-        "lolex": "^4.2.0",
-        "nise": "^1.5.2",
-        "supports-color": "^5.5.0"
+        "@sinonjs/commons": "^3.0.1",
+        "@sinonjs/fake-timers": "^11.2.2",
+        "@sinonjs/samsam": "^8.0.0",
+        "diff": "^5.2.0",
+        "nise": "^6.0.0",
+        "supports-color": "^7"
       },
       "dependencies": {
-        "diff": {
-          "version": "3.5.0",
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
           "dev": true
         },
         "supports-color": {
-          "version": "5.5.0",
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "^4.0.0"
           }
         }
       }
@@ -8978,6 +8991,8 @@
     },
     "type-detect": {
       "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
       "dev": true
     },
     "type-fest": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "lodash": "^4.17.21",
         "moment": "^2.30.1",
         "moment-range": "^4.0.2",
-        "pg": "^8.8.0",
+        "pg": "^8.11.5",
         "request": "^2.88.2",
         "request-promise-native": "^1.0.9",
         "winston": "^2.4.6"

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@hapi/hapi": "^21.3.9",
     "@hapi/lab": "^25.2.0",
     "auto-changelog": "^1.16.4",
-    "dotenv": "^16.0.2",
+    "dotenv": "^16.4.5",
     "sinon": "^7.5.0",
     "standard": "^17.1.0"
   }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "airbrake-js": "^1.6.8",
-    "cross-fetch": "^3.1.5",
+    "cross-fetch": "^4.0.0",
     "immutability-helper": "^3.1.1",
     "joi": "^17.6.2",
     "lodash": "^4.17.21",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "devDependencies": {
     "@hapi/code": "^9.0.3",
     "@hapi/hapi": "^21.3.9",
-    "@hapi/lab": "^25.0.1",
+    "@hapi/lab": "^25.2.0",
     "auto-changelog": "^1.16.4",
     "dotenv": "^16.0.2",
     "sinon": "^7.5.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "winston": "^2.4.6"
   },
   "devDependencies": {
-    "@hapi/code": "^9.0.1",
+    "@hapi/code": "^9.0.3",
     "@hapi/hapi": "^21.3.2",
     "@hapi/lab": "^25.0.1",
     "auto-changelog": "^1.16.4",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   },
   "devDependencies": {
     "@hapi/code": "^9.0.3",
-    "@hapi/hapi": "^21.3.2",
+    "@hapi/hapi": "^21.3.9",
     "@hapi/lab": "^25.0.1",
     "auto-changelog": "^1.16.4",
     "dotenv": "^16.0.2",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@hapi/code": "^9.0.3",
     "@hapi/hapi": "^21.3.9",
     "@hapi/lab": "^25.2.0",
-    "auto-changelog": "^1.16.4",
+    "auto-changelog": "^2.4.0",
     "dotenv": "^16.4.5",
     "sinon": "^7.5.0",
     "standard": "^17.1.0"

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "lodash": "^4.17.21",
     "moment": "^2.30.1",
     "moment-range": "^4.0.2",
-    "pg": "^8.8.0",
+    "pg": "^8.11.5",
     "request": "^2.88.2",
     "request-promise-native": "^1.0.9",
     "winston": "^2.4.6"

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "airbrake-js": "^1.6.8",
     "cross-fetch": "^4.0.0",
     "immutability-helper": "^3.1.1",
-    "joi": "^17.6.2",
+    "joi": "^17.13.1",
     "lodash": "^4.17.21",
     "moment": "^2.29.4",
     "moment-range": "^4.0.2",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "immutability-helper": "^3.1.1",
     "joi": "^17.13.1",
     "lodash": "^4.17.21",
-    "moment": "^2.29.4",
+    "moment": "^2.30.1",
     "moment-range": "^4.0.2",
     "pg": "^8.8.0",
     "request": "^2.88.2",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@hapi/lab": "^25.2.0",
     "auto-changelog": "^2.4.0",
     "dotenv": "^16.4.5",
-    "sinon": "^7.5.0",
+    "sinon": "^18.0.0",
     "standard": "^17.1.0"
   }
 }


### PR DESCRIPTION
A lot of the legacy projects use this repo. There have already been a lot of dependency updates made to this repo since its last release (Nov 2022).

In this PR we are going to update any dependencies that still are out of date. Then it looks like if we tag it and then create a release in GitHub, it will automatically push a new package to npm.

If it publishes successfully we will then be updating all of the legacy projects that have this helper as a dependency to its latest version.