### PR TITLE
Stop logging pool low warnings in the log

### DIFF
--- a/src/db/index.js
+++ b/src/db/index.js
@@ -5,10 +5,9 @@ const pg = require('pg')
 /**
  * Registers event listeners on the PG pool instance
  * @param {Pool} pool
- * @param {Object} config
  * @param {Logger} logger
  */
-const registerEventListeners = (pool, _config, logger) => {
+const registerEventListeners = (pool, logger) => {
   pool.on('error', err => {
     logger.error('Database pool error', err)
   })
@@ -21,7 +20,7 @@ const registerEventListeners = (pool, _config, logger) => {
  */
 const createPool = (config, logger) => {
   const pool = new pg.Pool(config)
-  registerEventListeners(pool, config, logger)
+  registerEventListeners(pool, logger)
   return pool
 }
 

--- a/src/db/index.js
+++ b/src/db/index.js
@@ -28,12 +28,7 @@ const isLogMessage = (config, pool) => {
  * @param {Object} config
  * @param {Logger} logger
  */
-const registerEventListeners = (pool, config, logger) => {
-  pool.on('acquire', () => {
-    if (isLogMessage(config, pool)) {
-      logger.info(formatLogMessage(pool))
-    }
-  })
+const registerEventListeners = (pool, _config, logger) => {
   pool.on('error', err => {
     logger.error('Database pool error', err)
   })

--- a/src/db/index.js
+++ b/src/db/index.js
@@ -1,26 +1,6 @@
 'use strict'
+
 const pg = require('pg')
-
-/**
- * Formats a log message if pool low on connections
- * @param {Object} pool - pg pool instance
- * @return {String} - the message to log
- */
-const formatLogMessage = pool => {
-  const { totalCount, idleCount, waitingCount } = pool
-  return `Pool low on connections::Total:${totalCount},Idle:${idleCount},Waiting:${waitingCount}`
-}
-
-/**
- * Determines whether to log message if pool low on connections
- * @param {Object} config - pg options
- * @param {Object} pool - pg pool instance
- * @return {Boolean} - whether to log message
- */
-const isLogMessage = (config, pool) => {
-  const { totalCount, idleCount, waitingCount } = pool
-  return totalCount === config.max && idleCount === 0 && waitingCount > 0
-}
 
 /**
  * Registers event listeners on the PG pool instance

--- a/test/db/index.test.js
+++ b/test/db/index.test.js
@@ -26,15 +26,13 @@ experiment('db/index.js', () => {
   })
 
   experiment('createPool', () => {
-    let pool, logger, client
+    let pool, logger
 
     beforeEach(async () => {
       logger = {
         error: sandbox.stub(),
         info: sandbox.stub()
       }
-
-      client = {}
 
       pool = db.createPool(config, logger)
     })

--- a/test/db/index.test.js
+++ b/test/db/index.test.js
@@ -43,33 +43,6 @@ experiment('db/index.js', () => {
       expect(pool.constructor.name).to.equal('BoundPool')
     })
 
-    experiment('when a client is acquired', () => {
-      experiment('if pool is waiting for an available client', () => {
-        beforeEach(async () => {
-          sandbox.stub(pool, 'waitingCount').get(() => 1)
-          sandbox.stub(pool, 'totalCount').get(() => 8)
-          pool.emit('acquire', client)
-        })
-
-        test('an info message is logged', async () => {
-          const [msg] = logger.info.lastCall.args
-          expect(msg).to.equal('Pool low on connections::Total:8,Idle:0,Waiting:1')
-        })
-      })
-
-      experiment('if pool is not waiting for an available client', () => {
-        beforeEach(async () => {
-          sandbox.stub(pool, 'waitingCount').get(() => 0)
-          sandbox.stub(pool, 'totalCount').get(() => 8)
-          pool.emit('acquire', client)
-        })
-
-        test('no messages are logged', async () => {
-          expect(logger.info.called).to.be.false()
-        })
-      })
-    })
-
     experiment('when a client errors', () => {
       const err = new Error('some terrible problem')
 


### PR DESCRIPTION
Anyone who has had to tail or dig into the [water-abstraction-import](https://github.com/DEFRA/water-abstraction-import) logs will have had to wade through reams of this.

```text
0|import  | 2025-01-27T15:30:24.002Z - info: Pool low on connections::Total:20,Idle:0,Waiting:10
0|import  | 2025-01-27T15:30:24.002Z - info: Pool low on connections::Total:20,Idle:0,Waiting:9
0|import  | 2025-01-27T15:30:24.003Z - info: Pool low on connections::Total:20,Idle:0,Waiting:8
0|import  | 2025-01-27T15:30:24.004Z - info: Pool low on connections::Total:20,Idle:0,Waiting:7
0|import  | 2025-01-27T15:30:24.004Z - info: Pool low on connections::Total:20,Idle:0,Waiting:6
0|import  | 2025-01-27T15:30:24.005Z - info: Pool low on connections::Total:20,Idle:0,Waiting:5
0|import  | 2025-01-27T15:30:24.006Z - info: Pool low on connections::Total:20,Idle:0,Waiting:4
0|import  | 2025-01-27T15:30:24.006Z - info: Pool low on connections::Total:20,Idle:0,Waiting:3
0|import  | 2025-01-27T15:30:24.006Z - info: Pool low on connections::Total:20,Idle:0,Waiting:2
0|import  | 2025-01-27T15:30:24.006Z - info: Pool low on connections::Total:20,Idle:0,Waiting:1
0|import  | 2025-01-27T15:30:24.007Z - info: Pool low on connections::Total:20,Idle:0,Waiting:5
0|import  | 2025-01-27T15:30:24.008Z - info: Pool low on connections::Total:20,Idle:0,Waiting:4
0|import  | 2025-01-27T15:30:24.008Z - info: Pool low on connections::Total:20,Idle:0,Waiting:3
0|import  | 2025-01-27T15:30:24.009Z - info: Pool low on connections::Total:20,Idle:0,Waiting:2
0|import  | 2025-01-27T15:30:24.009Z - info: Pool low on connections::Total:20,Idle:0,Waiting:1
0|import  | 2025-01-27T15:30:54.040Z - info: Pool low on connections::Total:20,Idle:0,Waiting:10
0|import  | 2025-01-27T15:30:54.040Z - info: Pool low on connections::Total:20,Idle:0,Waiting:9
0|import  | 2025-01-27T15:30:54.040Z - info: Pool low on connections::Total:20,Idle:0,Waiting:8
0|import  | 2025-01-27T15:30:54.041Z - info: Pool low on connections::Total:20,Idle:0,Waiting:7
0|import  | 2025-01-27T15:30:54.042Z - info: Pool low on connections::Total:20,Idle:0,Waiting:6
0|import  | 2025-01-27T15:30:54.042Z - info: Pool low on connections::Total:20,Idle:0,Waiting:5
0|import  | 2025-01-27T15:30:54.042Z - info: Pool low on connections::Total:20,Idle:0,Waiting:4
0|import  | 2025-01-27T15:30:54.043Z - info: Pool low on connections::Total:20,Idle:0,Waiting:3
0|import  | 2025-01-27T15:30:54.043Z - info: Pool low on connections::Total:20,Idle:0,Waiting:2
0|import  | 2025-01-27T15:30:54.043Z - info: Pool low on connections::Total:20,Idle:0,Waiting:1
```

Each night, this makes thousands of appearances in the logs. At this time, we don't have the capacity to rebuild _how_ they have made their connection to the DB. But we can stop this message from appearing and swamping the entries we want to see.